### PR TITLE
FIX: Downgrade ReportLab to 3.6.13, otherwise package conflict error …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ psycopg2-binary==2.9.7
 PyPDF2==3.0.1
 python-bidi==0.4.2
 pytz==2023.3
-reportlab==4.0.4
+reportlab==3.6.13
 six==1.16.0
 soupsieve==2.4.1
 sqlparse==0.4.4


### PR DESCRIPTION
…because xhtml2pdf requires a version less than 4.