### PR TITLE
Fix for Except block handles 'BaseException'

### DIFF
--- a/books/filters.py
+++ b/books/filters.py
@@ -17,7 +17,7 @@ class BookFilter(FilterSet):
         try:
             years = [(year, year) for year in Award.objects.values_list('year', flat=True).distinct().order_by('-year')]
             self.filters['award_year'].field.choices = [('', 'All Years')] + years
-        except:
+        except Exception:
             # If database doesn't exist yet, use empty choices
             self.filters['award_year'].field.choices = [('', 'All Years')]
 


### PR DESCRIPTION
Use a specific exception class instead of a bare `except:` in `BookFilter.__init__` (books/filters.py, around lines 17–22).  
Best fix without changing functionality: replace `except:` with `except Exception:`. This preserves the current fallback behavior (default “All Years” choices) for normal runtime/database errors, while no longer intercepting `BaseException` subclasses such as `KeyboardInterrupt` or `SystemExit`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._